### PR TITLE
Windows向けのorjsonのバージョンを3.9.15に固定

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ mkdocs-awesome-pages-plugin = { version = "*", optional = true }
 mkdocstrings = { version = "*", optional = true }
 mkdocstrings-python = { version = "*", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "*", optional= true}
-orjson = { version = "3.9.15", optional = true }
+orjson = [
+    { version = "3.9.15", optional = true, platform = 'windows'},
+    { version = "^3.9.15", optional = true, platform = 'linux'},
+    { version = "^3.9.15", optional = true, platform = 'darwin'}
+]
 
 [tool.poetry-version-plugin]
 source = "git-tag"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ mkdocs-awesome-pages-plugin = { version = "*", optional = true }
 mkdocstrings = { version = "*", optional = true }
 mkdocstrings-python = { version = "*", optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = "*", optional= true}
+orjson = { version = "3.9.15", optional = true }
 
 [tool.poetry-version-plugin]
 source = "git-tag"


### PR DESCRIPTION
related: [ijl/orjson#467](https://github.com/ijl/orjson/issues/467)